### PR TITLE
Add getNeighbors function to GraphMatrix and Implement Social Network Example

### DIFF
--- a/examples/socialNetwork.cpp
+++ b/examples/socialNetwork.cpp
@@ -1,0 +1,88 @@
+#include <iostream>
+#include <string>
+#include <set>
+#include "../include/GraphMatrix.h" 
+
+// Custom edge type for friendship details
+class Friendship
+{
+public:
+    int sinceYear;
+    std::string friendshipType;
+
+    Friendship(int sinceYear = 0, const std::string &friendshipType = "") 
+        : sinceYear(sinceYear), friendshipType(friendshipType) {}
+
+    bool operator==(const Friendship &other) const
+    {
+        return sinceYear == other.sinceYear && friendshipType == other.friendshipType;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const Friendship &friendship)
+    {
+        os << "{ Since: " << friendship.sinceYear << ", Type: \"" << friendship.friendshipType << "\" }";
+        return os;
+    }
+};
+
+int main()
+{
+    // Create a graph to represent a social network
+    Appledore::GraphMatrix<std::string, Friendship, Appledore::UndirectedG> socialGraph;
+
+    // Add users as vertices
+    socialGraph.addVertex("Alice");
+    socialGraph.addVertex("Bob");
+    socialGraph.addVertex("Charlie");
+    socialGraph.addVertex("David");
+
+    // Define some friendships (edges) between users
+    Friendship f1{2015, "Best Friends"};
+    Friendship f2{2018, "Work Friends"};
+    Friendship f3{2020, "College Friends"};
+
+    // Add friendship relationships (edges)
+    socialGraph.addEdge("Alice", "Bob", f1);  // Alice and Bob are best friends
+    socialGraph.addEdge("Alice", "Charlie", f2); // Alice and Charlie are work friends
+    socialGraph.addEdge("Bob", "David", f3);  // Bob and David are college friends
+    socialGraph.addEdge("Charlie", "David", f2); // Charlie and David are work friends
+
+    // Get and print all users (vertices)
+    std::cout << "Users in the social network: ";
+    for (const auto &user : socialGraph.getVertices())
+    {
+        std::cout << user << ", ";
+    }
+    std::cout << "\n";
+
+    // Get and print neighbors (friends) for "Alice"
+    std::cout << "\nFriends of Alice:\n";
+    auto friends = socialGraph.getNeighbors("Alice");
+    for (const auto &friendName : friends)
+    {
+        std::cout << " - " << friendName << "\n";
+    }
+
+    // Check if Alice and Bob are friends
+    std::cout << "\nAre Alice and Bob friends? ";
+    if (socialGraph("Alice", "Bob"))
+    {
+        std::cout << "Yes\n";
+    }
+    else
+    {
+        std::cout << "No\n";
+    }
+
+    // Try to get a non-existing friendship (will throw an exception)
+    try
+    {
+        socialGraph.getEdge("Alice", "David"); // Throws error because there's no direct friendship
+    }
+    catch (const std::exception &e)
+    {
+        std::cout << "Error: " << e.what() << "\n";
+    }
+
+    return 0;
+}

--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -101,7 +101,7 @@ namespace Appledore
 
             adjacencyMatrix[getIndex(srcIndex, destIndex)] = EdgeInfo<EdgeType>(edge);
 
-            if constexpr (std::is_same_v<Direction, UndirectedG>)
+            if (!isDirected)
             {
                 adjacencyMatrix[getIndex(destIndex, srcIndex)] = EdgeInfo<EdgeType>(edge);
             }
@@ -120,7 +120,7 @@ namespace Appledore
 
             adjacencyMatrix[getIndex(srcIndex, destIndex)] = EdgeInfo<EdgeType>();
 
-            if constexpr (std::is_same_v<Direction, UndirectedG>)
+            if (!isDirected)
             {
                 adjacencyMatrix[getIndex(destIndex, srcIndex)] = EdgeInfo<EdgeType>();
             }
@@ -165,16 +165,16 @@ namespace Appledore
         {
             if (!vertexToIndex.count(src) || !vertexToIndex.count(dest))
             {
-                throw std::invalid_argument("One of both vertices do not exist!");
+                throw std::invalid_argument("One or both vertices do not exist!");
             }
             size_t srcIndex = vertexToIndex.at(src);
             size_t destIndex = vertexToIndex.at(dest);
 
-            auto &egdeValue = adjacencyMatrix[getIndex(srcIndex, destIndex)];
+            auto &edgeValue = adjacencyMatrix[getIndex(srcIndex, destIndex)];
 
-            if (egdeValue.has_value())
+            if (edgeValue.has_value())
             {
-                return egdeValue.value().value;
+                return edgeValue.value().value;
             }
             else
             {
@@ -204,8 +204,8 @@ namespace Appledore
             return edges;
         }
 
-        // Get neighbors for a vertex (using only a std::set for both weighted and unweighted graphs)
-        auto getNeighbors(const VertexType& vertex) const
+        // Get neighbors for a vertex
+        std::set<VertexType> getNeighbors(const VertexType& vertex) const
         {
             if (!vertexToIndex.count(vertex))
             {
@@ -224,13 +224,10 @@ namespace Appledore
                     neighbors.insert(indexToVertex[destIndex]);
                 }
 
-                // For undirected graphs, also check the reverse direction
-                if constexpr (std::is_same_v<Direction, UndirectedG>)
+                // Check reverse direction only if the graph is undirected
+                if (!isDirected && adjacencyMatrix[getIndex(destIndex, vertexIndex)].has_value())
                 {
-                    if (adjacencyMatrix[getIndex(destIndex, vertexIndex)].has_value())
-                    {
-                        neighbors.insert(indexToVertex[destIndex]);
-                    }
+                    neighbors.insert(indexToVertex[destIndex]);
                 }
             }
 
@@ -244,6 +241,7 @@ namespace Appledore
         size_t numVertices = 0;
         bool isDirected;
         bool isWeighted;
+
         inline size_t getIndex(size_t src, size_t dest) const
         {
             return src * numVertices + dest;


### PR DESCRIPTION
 This PR adds the getNeighbors function to the GraphMatrix class, which retrieves neighboring vertices of a specified vertex as a std::set. The function works for both directed and undirected, weighted and unweighted graphs. A social network example is included to demonstrate this functionality, where users are vertices and friendships are edges. The example shows how to add vertices and edges, use getNeighbors to fetch friends of a user, and handle errors for non-existent edges.
 
Tested getNeighbors in the social network example to ensure it returns correct neighbors and handles edge existence checks properly.

fixes #2 