### PR TITLE
Feature : Added vertex removal functionality to GraphMatrix

### DIFF
--- a/examples/vertexRemoval.cpp
+++ b/examples/vertexRemoval.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include "../include/GraphMatrix.h" 
+int main()
+{
+    // Here, we assume you are using:
+    // GraphMatrix<VertexType, EdgeType, Direction>
+    // Let's pick: GraphMatrix<std::string, int, UndirectedG> for this demo.
+    Appledore::GraphMatrix<std::string, int, Appledore::UndirectedG> graph;
+
+   
+    graph.addVertex("A", "B", "C", "D");
+
+    // 2. Add edges
+    // (For an undirected graph, an edge from A to B also implies an edge from B to A.)
+    graph.addEdge("A", "B", 1);
+    graph.addEdge("B", "C", 2);
+    graph.addEdge("C", "D", 3);
+    graph.addEdge("A", "D", 4);
+
+    // 3. Display the initial vertices
+    std::cout << "Initial Vertices:\n";
+    for (const auto &v : graph.getVertices())
+    {
+        std::cout << v << " ";
+    }
+    std::cout << "\n\n";
+
+    // 4. Display the initial edges
+    std::cout << "Initial Edges (Undirected):\n";
+    auto edges = graph.getAllEdges();
+    for (const auto &edge : edges)
+    {
+        auto &[src, dest, val] = edge;
+        std::cout << src << " --(" << val << ")--> " << dest << "\n";
+    }
+    std::cout << "\n";
+
+    // 5. Remove a vertex (say "C")
+    std::cout << "Removing vertex: C\n\n";
+    try
+    {
+        graph.removeVertex("C");
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Error: " << e.what() << "\n";
+    }
+
+    // 6. Display the updated vertices
+    std::cout << "Updated Vertices:\n";
+    for (const auto &v : graph.getVertices())
+    {
+        std::cout << v << " ";
+    }
+    std::cout << "\n\n";
+
+    // 7. Display the updated edges
+    std::cout << "Updated Edges (Undirected):\n";
+    edges = graph.getAllEdges();
+    for (const auto &edge : edges)
+    {
+        auto &[src, dest, val] = edge;
+        std::cout << src << " --(" << val << ")--> " << dest << "\n";
+    }
+    std::cout << "\n";
+
+    // 8. Try checking edges involving removed vertex "C"
+    std::cout << "Attempting to check edge from removed vertex C:\n";
+    try
+    {
+        // Should throw an exception since "C" no longer exists
+        bool edgeExists = graph.hasEdge("C", "D");
+        std::cout << "Unexpected: 'C' to 'D' edge found? " << (edgeExists ? "Yes" : "No") << "\n";
+    }
+    catch (const std::exception &e)
+    {
+        std::cerr << "Expected error: " << e.what() << "\n";
+    }
+
+    return 0;
+}

--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -8,7 +8,6 @@
 #include <stack>
 #include <algorithm>
 #include <set>
-#include "MixedGraph.h"
 
 namespace Appledore
 {

--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -8,6 +8,7 @@
 #include <stack>
 #include <algorithm>
 #include <set>
+#include "MixedGraph.h"
 
 namespace Appledore
 {
@@ -344,6 +345,53 @@ namespace Appledore
             }
 
             return allPaths;
+        }
+
+        // ---------------------------------------------------------
+        // NEW METHOD: removeVertex() 
+        // ---------------------------------------------------------
+        void removeVertex(const VertexType &vert)
+        {
+            if (!vertexToIndex.count(vert))
+            {
+                throw std::invalid_argument("Vertex does not exist in the graph.");
+            }
+
+            size_t remIdx = vertexToIndex[vert];
+            size_t lastIdx = numVertices - 1;
+
+            // Swap row/column of the vertex to be removed with the last vertex, if needed
+            if (remIdx != lastIdx)
+            {
+                for (size_t c = 0; c < numVertices; ++c)
+                {
+                    adjacencyMatrix[getIndex(remIdx, c)] =
+                        adjacencyMatrix[getIndex(lastIdx, c)];
+                }
+                for (size_t r = 0; r < numVertices; ++r)
+                {
+                    adjacencyMatrix[getIndex(r, remIdx)] =
+                        adjacencyMatrix[getIndex(r, lastIdx)];
+                }
+                VertexType movedVertex = indexToVertex[lastIdx];
+                vertexToIndex[movedVertex] = remIdx;
+                indexToVertex[remIdx] = movedVertex;
+            }
+
+            // Clear the last row/column
+            for (size_t i = 0; i < numVertices; ++i)
+            {
+                adjacencyMatrix[getIndex(i, lastIdx)] = std::nullopt;
+                adjacencyMatrix[getIndex(lastIdx, i)] = std::nullopt;
+            }
+
+            // Erase the vertex from data structures
+            vertexToIndex.erase(vert);
+            indexToVertex.pop_back();
+            numVertices--;
+
+            // Resize adjacencyMatrix
+            adjacencyMatrix.resize(numVertices * numVertices);
         }
 
     private:


### PR DESCRIPTION
## Fixes the issue and closes #12 

### **Key Steps and Logic**

1. **Check Vertex Existence**:
   - Before attempting to remove a vertex, it's crucial to verify if the vertex actually exists in the graph.
   - If the vertex does not exist, an exception is thrown to prevent any further operations and to notify the caller of the error.

2. **Identifying and Swapping Vertices**:
   - The method identifies the index (`remIdx`) of the vertex to be removed and the last vertex's index (`lastIdx`).
   - If the vertex to be removed is not the last one in our data structures, we swap its position with the last vertex. This is done to maintain a compact adjacency matrix and to simplify the removal process.
   - Swapping involves copying the last vertex's row and column data to the row and column of the vertex to be removed.

3. **Updating Vertex Indexes**:
   - After swapping, the internal mappings (`vertexToIndex` and `indexToVertex`) are updated to reflect the new positions of the vertices that were swapped. This ensures that all future operations that involve these vertices refer to the correct data.

4. **Clearing Data**:
   - Once the vertex is swapped to the last position, its corresponding row and column in the adjacency matrix are cleared. This is done by setting all values to `std::nullopt`, indicating the absence of edges.
   - This step ensures that there are no residual edges that could falsely represent connections that no longer exist after the vertex is removed.

5. **Removing Vertex from Structures**:
   - The vertex is then removed from the mapping and list structures. This involves erasing the vertex entry from the `vertexToIndex` map and removing the last entry from the `indexToVertex` list (which now corresponds to the vertex that was moved due to the swap).

6. **Resize Adjacency Matrix**:
   - The adjacency matrix is resized to reflect the new size of the graph after the vertex removal. This is calculated as `numVertices * numVertices`, where `numVertices` is decremented to account for the removed vertex.
   - Resizing is crucial to maintain a correctly sized matrix for any subsequent operations on the graph.

### **Efficiency and Implementation Notes**

- **Efficiently Handling Vertex Removal**: The process of swapping the vertex with the last one and then resizing the matrix is a time-efficient way to handle vertex removal. It avoids the need to rebuild the matrix from scratch and simplifies the removal of vertices by concentrating all changes to the matrix's end, making it easier to manage.
- **Matrix Compactness**: By keeping the adjacency matrix compact and contiguous, this approach ensures that the graph remains efficient for traversal and updates, even as vertices are added or removed.
- **Error Handling**: Thorough error handling via exceptions ensures that attempts to operate on non-existent vertices are caught and handled gracefully, maintaining the robustness of the graph management system.

This method leverages efficient data structure manipulation to maintain graph integrity and performance, even as vertices are dynamically added or removed.