### PR TITLE
Feat : Add custom exception classes for graph operations

### DIFF
--- a/include/GraphExceptions.h
+++ b/include/GraphExceptions.h
@@ -22,7 +22,7 @@ namespace Appledore {
     }
 
     template<typename T>
-    std::enable_if_t<std::is_fundamental<T>::value || is_streamable<T>::value && std::is_fundamental<T>::value, std::string>
+    std::enable_if_t<std::is_fundamental<T>::value || (is_streamable<T>::value && std::is_fundamental<T>::value), std::string>
     toString(const T& value) {
         std::ostringstream ss;
         ss << value;

--- a/include/graphExceptions.h
+++ b/include/graphExceptions.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include <exception>
+#include <string>
+#include <sstream>
+#include <type_traits>
+
+namespace Appledore {
+
+    // Base class for all graph-related exceptions
+    class GraphException : public std::exception {
+    public:
+        explicit GraphException(const std::string& message)
+            : m_message(message) 
+        {
+        }
+
+        const char* what() const noexcept override {
+            return m_message.c_str();
+        }
+
+    protected:
+        std::string m_message;
+
+        // Helper to convert any vertex type to string
+        template<typename T>
+        static std::string toString(const T& value) {
+            if constexpr (std::is_same_v<T, std::string>) {
+                return value;
+            } else {
+                std::ostringstream ss;
+                ss << value;
+                return ss.str();
+            }
+        }
+    };
+
+    // Thrown when attempting to access a non-existent vertex
+    class VertexNotFoundException : public GraphException {
+    public:
+        template<typename T>
+        explicit VertexNotFoundException(const T& vertexId)
+            : GraphException("Vertex not found: " + toString(vertexId))
+        {
+        }
+
+        explicit VertexNotFoundException(const std::string& message)
+            : GraphException(message)
+        {
+        }
+    };
+
+    // Thrown when an operation targets a non-existent edge
+    class EdgeNotFoundException : public GraphException {
+    public:
+        template<typename T>
+        EdgeNotFoundException(const T& source, const T& target)
+            : GraphException("Edge not found between vertices: " + 
+                           toString(source) + " -> " + toString(target))
+        {
+        }
+
+        explicit EdgeNotFoundException(const std::string& message)
+            : GraphException(message)
+        {
+        }
+    };
+
+    // Thrown when adding a vertex that already exists
+    class DuplicateVertexException : public GraphException {
+    public:
+        template<typename T>
+        explicit DuplicateVertexException(const T& vertexId)
+            : GraphException("Duplicate vertex: " + toString(vertexId))
+        {
+        }
+
+        explicit DuplicateVertexException(const std::string& message)
+            : GraphException(message)
+        {
+        }
+    };
+
+    // Thrown for invalid operations on edges (e.g., adding edge between non-existent vertices)
+    class InvalidEdgeOperationException : public GraphException {
+    public:
+        template<typename T>
+        InvalidEdgeOperationException(const T& source, const T& target, 
+                                    const std::string& reason)
+            : GraphException("Invalid edge operation between vertices " + 
+                           toString(source) + " -> " + toString(target) +
+                           ": " + reason)
+        {
+        }
+
+        explicit InvalidEdgeOperationException(const std::string& message)
+            : GraphException(message)
+        {
+        }
+    };
+
+    // Generic exception for unexpected graph operations
+    class GraphOperationException : public GraphException {
+    public:
+        explicit GraphOperationException(const std::string& operation, 
+                                       const std::string& reason)
+            : GraphException("Graph operation '" + operation + "' failed: " + reason)
+        {
+        }
+
+        explicit GraphOperationException(const std::string& message)
+            : GraphException(message)
+        {
+        }
+    };
+
+} // namespace Appledore

--- a/include/graphExceptions.h
+++ b/include/graphExceptions.h
@@ -1,17 +1,47 @@
 #pragma once
 
 #include <exception>
-#include <string>
 #include <sstream>
+#include <string>
 #include <type_traits>
+#include <typeinfo>
 
 namespace Appledore {
 
-    // Base class for all graph-related exceptions
+    // SFINAE Trait to detect if type T can be streamed to std::ostream
+    template<typename T, typename = void>
+    struct is_streamable : std::false_type {};
+
+    template<typename T>
+    struct is_streamable<
+        T, 
+        std::void_t<decltype(std::declval<std::ostream&>() << std::declval<const T&>())>
+    > : std::true_type {};
+
+    // Helper functions to convert any type to string with proper fallback for non-streamable types
+    inline std::string toString(const std::string& value) {
+        return value;
+    }
+
+    template<typename T>
+    std::enable_if_t<is_streamable<T>::value, std::string>
+    toString(const T& value) {
+        std::ostringstream ss;
+        ss << value;
+        return ss.str();
+    }
+
+    template<typename T>
+    std::enable_if_t<!is_streamable<T>::value, std::string>
+    toString(const T&) {
+        return std::string{"[Unprintable type: "} + typeid(T).name() + "]";
+    }
+
+    // Base exception class for all graph-related errors
     class GraphException : public std::exception {
     public:
-        explicit GraphException(const std::string& message)
-            : m_message(message) 
+        explicit GraphException(std::string message)
+            : m_message(std::move(message))
         {
         }
 
@@ -19,98 +49,157 @@ namespace Appledore {
             return m_message.c_str();
         }
 
+        const std::string& message() const {
+            return m_message;
+        }
+
     protected:
         std::string m_message;
-
-        // Helper to convert any vertex type to string
-        template<typename T>
-        static std::string toString(const T& value) {
-            if constexpr (std::is_same_v<T, std::string>) {
-                return value;
-            } else {
-                std::ostringstream ss;
-                ss << value;
-                return ss.str();
-            }
-        }
     };
 
-    // Thrown when attempting to access a non-existent vertex
+    // Exception for operations on non-existent vertices
     class VertexNotFoundException : public GraphException {
     public:
         template<typename T>
         explicit VertexNotFoundException(const T& vertexId)
-            : GraphException("Vertex not found: " + toString(vertexId))
-        {
-        }
+            : GraphException(formatMessage(vertexId))
+            , m_vertexId(toString(vertexId))
+        {}
 
         explicit VertexNotFoundException(const std::string& message)
-            : GraphException(message)
-        {
+            : GraphException(message), m_vertexId("[Unknown Vertex]")
+        {}
+
+        const std::string& vertexId() const {
+            return m_vertexId;
+        }
+
+    private:
+        std::string m_vertexId;
+
+        template<typename T>
+        static std::string formatMessage(const T& id) {
+            return "Vertex not found: " + toString(id);
         }
     };
 
-    // Thrown when an operation targets a non-existent edge
+    // Exception for operations on non-existent edges
     class EdgeNotFoundException : public GraphException {
     public:
         template<typename T>
         EdgeNotFoundException(const T& source, const T& target)
-            : GraphException("Edge not found between vertices: " + 
-                           toString(source) + " -> " + toString(target))
-        {
-        }
+            : GraphException(formatMessage(source, target))
+            , m_sourceId(toString(source))
+            , m_targetId(toString(target))
+        {}
 
         explicit EdgeNotFoundException(const std::string& message)
             : GraphException(message)
-        {
+            , m_sourceId("[Unknown]"), m_targetId("[Unknown]")
+        {}
+
+        const std::string& sourceId() const { return m_sourceId; }
+        const std::string& targetId() const { return m_targetId; }
+
+    private:
+        std::string m_sourceId;
+        std::string m_targetId;
+
+        template<typename T>
+        static std::string formatMessage(const T& s, const T& t) {
+            return "Edge not found between vertices: " +
+                   toString(s) + " -> " + toString(t);
         }
     };
 
-    // Thrown when adding a vertex that already exists
+    // Exception for adding duplicate vertices
     class DuplicateVertexException : public GraphException {
     public:
         template<typename T>
         explicit DuplicateVertexException(const T& vertexId)
-            : GraphException("Duplicate vertex: " + toString(vertexId))
-        {
-        }
+            : GraphException(formatMessage(vertexId))
+            , m_vertexId(toString(vertexId))
+        {}
 
         explicit DuplicateVertexException(const std::string& message)
-            : GraphException(message)
-        {
+            : GraphException(message), m_vertexId("[Unknown Vertex]")
+        {}
+
+        const std::string& vertexId() const {
+            return m_vertexId;
+        }
+
+    private:
+        std::string m_vertexId;
+
+        template<typename T>
+        static std::string formatMessage(const T& id) {
+            return "Duplicate vertex: " + toString(id);
         }
     };
 
-    // Thrown for invalid operations on edges (e.g., adding edge between non-existent vertices)
+    // Exception for invalid edge operations (e.g., adding edges between non-existent vertices)
     class InvalidEdgeOperationException : public GraphException {
     public:
         template<typename T>
-        InvalidEdgeOperationException(const T& source, const T& target, 
-                                    const std::string& reason)
-            : GraphException("Invalid edge operation between vertices " + 
-                           toString(source) + " -> " + toString(target) +
-                           ": " + reason)
-        {
-        }
+        InvalidEdgeOperationException(const T& source, const T& target,
+                                      const std::string& reason)
+            : GraphException(formatMessage(source, target, reason))
+            , m_sourceId(toString(source))
+            , m_targetId(toString(target))
+            , m_reason(reason)
+        {}
 
         explicit InvalidEdgeOperationException(const std::string& message)
             : GraphException(message)
-        {
+            , m_sourceId("[Unknown]"), m_targetId("[Unknown]"), m_reason("[Unknown]")
+        {}
+
+        const std::string& sourceId() const { return m_sourceId; }
+        const std::string& targetId() const { return m_targetId; }
+        const std::string& reason()   const { return m_reason;   }
+
+    private:
+        std::string m_sourceId;
+        std::string m_targetId;
+        std::string m_reason;
+
+        template<typename T>
+        static std::string formatMessage(const T& s, const T& t,
+                                         const std::string& reason) {
+            std::ostringstream oss;
+            oss << "Invalid edge operation between vertices: "
+                << toString(s) << " -> " << toString(t)
+                << " | Reason: " << reason;
+            return oss.str();
         }
     };
 
     // Generic exception for unexpected graph operations
     class GraphOperationException : public GraphException {
     public:
-        explicit GraphOperationException(const std::string& operation, 
-                                       const std::string& reason)
-            : GraphException("Graph operation '" + operation + "' failed: " + reason)
-        {
-        }
+        explicit GraphOperationException(std::string operation, std::string reason)
+            : GraphException(formatMessage(operation, reason))
+            , m_operation(std::move(operation))
+            , m_reason(std::move(reason))
+        {}
 
         explicit GraphOperationException(const std::string& message)
             : GraphException(message)
-        {
+            , m_operation("[Unknown Operation]")
+            , m_reason("[Unknown Reason]")
+        {}
+
+        const std::string& operation() const { return m_operation; }
+        const std::string& reason()    const { return m_reason; }
+
+    private:
+        std::string m_operation;
+        std::string m_reason;
+
+        static std::string formatMessage(const std::string& op,
+                                         const std::string& reason) {
+            return "Graph operation '" + op + "' failed: " + reason;
         }
     };
 


### PR DESCRIPTION
## Fixes and Closes the issue : #7 

This PR adds a new header file `graphExceptions.h` that implements custom exception classes for graph-related operations.

### Features Added
- Base class `GraphException` inheriting from `std::exception`
- Specific exception classes for common graph operations:
  - `VertexNotFoundException`
  - `EdgeNotFoundException`
  - `DuplicateVertexException`
  - `InvalidEdgeOperationException`
  - `GraphOperationException`

### Implementation Details
- Template support for different vertex types
- Consistent error message formatting
- Clean and minimal design
- Modern C++ features (C++17 compatible)
- Descriptive error messages with context

### Usage
These exceptions can be used across the codebase to provide consistent error handling for graph operations. Example:
```cpp
if (!vertexExists(vertex)) {
    throw VertexNotFoundException(vertex);
}