### PR TITLE
Add graph density calculation method 

### DIFF
--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -346,7 +346,43 @@ namespace Appledore
             return allPaths;
         }
 
-         // ---------------------------------------------------------
+        // Calculate the density of the graph
+        // For undirected graphs: density = (2 * |E|) / (|V| * (|V| - 1))
+        // For directed graphs: density = |E| / (|V| * (|V| - 1))
+        [[nodiscard]] double density() const {
+            if (numVertices <= 1) {
+                // If there are 0 or 1 vertices, we define density as 0.0
+                return 0.0;
+            }
+
+            // Count how many edges exist
+            size_t edgeCount = 0;
+            for (size_t i = 0; i < numVertices; ++i) {
+                for (size_t j = 0; j < numVertices; ++j) {
+                    if (adjacencyMatrix[getIndex(i, j)].has_value()) {
+                        edgeCount++;
+                    }
+                }
+            }
+
+            // In an undirected graph, each edge appears twice (i->j and j->i)
+            if (!isDirected) {
+                edgeCount /= 2;
+            }
+
+            // Denominator for the formula: |V| * (|V| - 1)
+            double denominator = static_cast<double>(numVertices) * (numVertices - 1);
+
+            // For an undirected graph, the formula multiplies edge count by 2
+            double numerator = isDirected
+                ? static_cast<double>(edgeCount)
+                : 2.0 * static_cast<double>(edgeCount);
+
+            return (numerator / denominator);
+        }
+
+
+        // ---------------------------------------------------------
         // NEW METHOD: removeVertex() 
         // ---------------------------------------------------------
         void removeVertex(const VertexType &vert)

--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -351,36 +351,25 @@ namespace Appledore
         // For directed graphs: density = |E| / (|V| * (|V| - 1))
         [[nodiscard]] double density() const {
             if (numVertices <= 1) {
-                // If there are 0 or 1 vertices, we define density as 0.0
                 return 0.0;
             }
 
-            // Count how many edges exist
             size_t edgeCount = 0;
-            for (size_t i = 0; i < numVertices; ++i) {
-                for (size_t j = 0; j < numVertices; ++j) {
-                    if (adjacencyMatrix[getIndex(i, j)].has_value()) {
-                        edgeCount++;
-                    }
+            for (size_t i = 0; i < adjacencyMatrix.size(); ++i) {
+                if (adjacencyMatrix[i].has_value()) {
+                    edgeCount++;
                 }
             }
 
-            // In an undirected graph, each edge appears twice (i->j and j->i)
             if (!isDirected) {
                 edgeCount /= 2;
             }
 
-            // Denominator for the formula: |V| * (|V| - 1)
             double denominator = static_cast<double>(numVertices) * (numVertices - 1);
+            double numerator = isDirected ? static_cast<double>(edgeCount) : 2.0 * static_cast<double>(edgeCount);
 
-            // For an undirected graph, the formula multiplies edge count by 2
-            double numerator = isDirected
-                ? static_cast<double>(edgeCount)
-                : 2.0 * static_cast<double>(edgeCount);
-
-            return (numerator / denominator);
+            return numerator / denominator;
         }
-
 
         // ---------------------------------------------------------
         // NEW METHOD: removeVertex() 


### PR DESCRIPTION
Fixes and Closes the issue : #6 

### Description

1. **Early Return**  
   - If `numVertices <= 1`, the density is **0** by definition (no edges possible).

2. **Edge Counting**  
   - We increment `edgeCount` for every “occupied” cell in the adjacency matrix.  
   - In an **undirected** matrix, each edge is counted twice (i->j and j->i), so we divide by 2.

3. **Explicit Cast to `double`**  
   - Casting `numVertices` and `edgeCount` to `double` ensures **floating-point** division, avoiding any unintended integer division.

4. **Correct Formula**  
   - **Undirected**: \(\frac{2 \times |E|}{|V| \times (|V| - 1)}\)  
   - **Directed**: \(\frac{|E|}{|V| \times (|V| - 1)}\)


