### PR TITLE
[Fix] Fixed missing default ctor for EdgeInfo in GraphMarix

### DIFF
--- a/include/GraphMatrix.h
+++ b/include/GraphMatrix.h
@@ -44,6 +44,7 @@ namespace Appledore
         EdgeType value;
 
         EdgeInfo(const EdgeType &value) : value(value) {}
+        EdgeInfo() {}
     };
 
     // GraphMatrix class template


### PR DESCRIPTION
Added default constructor in ``EdgeInfo`` structure of ``GraphMatrix`` implementation.
```cpp
        EdgeInfo() {}
```
Without the default constructor the creating of unweighted graphs was not possible and would throw an error.
Required/originated from here.
```cpp
void addEdge(const VertexType &src, const VertexType &dest)
        {
            if (!vertexToIndex.count(src) || !vertexToIndex.count(dest))
            {
                throw std::invalid_argument("One or both vertices do not exist");
            }

            size_t srcIndex = vertexToIndex.at(src);
            size_t destIndex = vertexToIndex.at(dest);

            adjacencyMatrix[getIndex(srcIndex, destIndex)] = EdgeInfo<EdgeType>();

            if (!isDirected)
            {
                adjacencyMatrix[getIndex(destIndex, srcIndex)] = EdgeInfo<EdgeType>();
            }
        }
```